### PR TITLE
feat: aggregate pre/post state allocs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4285,7 +4285,9 @@ dependencies = [
 name = "opt8n"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "anvil",
+ "anvil-core",
  "clap",
  "color-eyre",
  "futures",

--- a/crates/op-test-vectors/src/execution.rs
+++ b/crates/op-test-vectors/src/execution.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 pub struct ExecutionFixture {
     pub env: ExecutionEnvironment,
     pub alloc: HashMap<Address, AccountState>,
+    pub out_alloc: HashMap<Address, AccountState>,
     #[serde(rename = "txs")]
     pub transactions: Vec<TypedTransaction>,
     pub result: ExecutionResult,

--- a/crates/opt8n/Cargo.toml
+++ b/crates/opt8n/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+alloy = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 op-test-vectors = { workspace = true }
 clap = { workspace = true }
@@ -11,3 +12,4 @@ tokio = { workspace = true }
 futures = { workspace = true }
 color-eyre = { workspace = true }
 anvil = { workspace = true }
+anvil-core = { workspace = true }

--- a/crates/opt8n/src/main.rs
+++ b/crates/opt8n/src/main.rs
@@ -11,7 +11,7 @@ pub struct Args {}
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     let _args = Args::parse();
-    let mut opt8n = Opt8n::new(None).await;
+    let mut opt8n = Opt8n::new(None, None).await;
     opt8n.listen().await;
     Ok(())
 }

--- a/crates/opt8n/src/opt8n.rs
+++ b/crates/opt8n/src/opt8n.rs
@@ -1,17 +1,22 @@
+use crate::cmd::Opt8nCommand;
+use alloy::rpc::types::{
+    anvil::Forking,
+    trace::geth::{GethDebugTracingOptions, GethTrace, PreStateConfig, PreStateFrame},
+};
 use anvil::{eth::EthApi, NodeConfig, NodeHandle};
+use anvil_core::eth::transaction::TypedTransaction;
 use futures::StreamExt;
 use op_test_vectors::execution::{ExecutionFixture, ExecutionReceipt, ExecutionResult};
-
-use crate::cmd::Opt8nCommand;
 
 pub struct Opt8n {
     pub eth_api: EthApi,
     pub node_handle: NodeHandle,
     pub execution_fixture: ExecutionFixture,
+    pub fork: Forking,
 }
 
 impl Opt8n {
-    pub async fn new(node_config: Option<NodeConfig>) -> Self {
+    pub async fn new(node_config: Option<NodeConfig>, fork: Option<Forking>) -> Self {
         let node_config = node_config.unwrap_or_default().with_optimism(true);
         let (eth_api, node_handle) = anvil::spawn(node_config).await;
 
@@ -19,18 +24,23 @@ impl Opt8n {
             eth_api,
             node_handle,
             execution_fixture: ExecutionFixture::default(),
+            fork: fork.unwrap_or_default(),
         }
     }
 
     pub async fn listen(&mut self) {
         // TODO: I might ahve to update this to use alloy if the relevent methods are not available
         let mut new_blocks = self.eth_api.backend.new_block_notifications();
-
         loop {
             tokio::select! {
                 command = self.receive_command() => {
+                    // TODO: Update to save fixture cmd
                     if command == Opt8nCommand::Exit {
-                        break;
+                        // Reset the fork
+                        let _ = self.eth_api.backend.reset_fork(self.fork.clone()).await;
+                        // TODO Mine all transactions in the execution fixture in aggregate
+                        // And populate the execution fixture with by fetching the block by block number
+                        // break;
                     }
                     self.execute(command);
                 }
@@ -39,14 +49,13 @@ impl Opt8n {
                     if let Some(new_block) = new_block {
                         if let Some(block) = self.eth_api.backend.get_block_by_hash(new_block.hash) {
                             let transactions = block.transactions.into_iter().map(|tx| tx.transaction).collect::<Vec<_>>();
+                            self.update_alloc(&transactions).await;
 
                             // TODO: get receipts
                             let receipts: Vec<ExecutionReceipt> = vec![];
-
                             self.execution_fixture.transactions.extend(transactions);
-
                             let block_header = block.header;
-                            let execution_result = ExecutionResult{
+                            let execution_result = ExecutionResult {
                                 state_root: block_header.state_root,
                                 tx_root: block_header.transactions_root,
                                 receipt_root: block_header.receipts_root,
@@ -57,14 +66,37 @@ impl Opt8n {
 
                             self.execution_fixture.result = execution_result;
                         }
-
-
-
-
-
                     }
-
                 }
+            }
+        }
+    }
+
+    /// Updates the pre and post state allocations of the [ExecutionFixture].
+    async fn update_alloc(&mut self, transactions: &Vec<TypedTransaction>) {
+        // TODO: Make this concurrent
+        for transaction in transactions {
+            if let Ok(GethTrace::PreStateTracer(PreStateFrame::Diff(frame))) = self
+                .eth_api
+                .backend
+                .debug_trace_transaction(
+                    transaction.hash(),
+                    GethDebugTracingOptions::default().with_prestate_config(PreStateConfig {
+                        diff_mode: Some(true),
+                    }),
+                )
+                .await
+            {
+                frame.pre.into_iter().for_each(|(address, account)| {
+                    self.execution_fixture
+                        .alloc
+                        .entry(address)
+                        .or_insert(account);
+                });
+
+                frame.post.into_iter().for_each(|(address, account)| {
+                    self.execution_fixture.out_alloc.insert(address, account);
+                });
             }
         }
     }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

- Aggregates pre/post state allocs on the Execution Fixture over all transactions mined. 
- Resets anvil fork on exit, and updates `Opt8n` to initialize with a `Forking` configuration to reinstantiate the fork to re-mine the block of transactions.
- Adds `out_alloc` field to the `ExecutionFixture` per specification

Ref: https://ethereum-tests.readthedocs.io/en/develop/t8ntool-ref.html

