### PR TITLE
feat: Initial opd8n Stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4397,6 +4397,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "opd8n"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "color-eyre",
+ "futures",
+ "op-test-vectors",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
-members = ["crates/*", "bin/opt8n"]
-default-members = ["bin/opt8n"]
+members = ["crates/*", "bin/opt8n", "bin/opd8n"]
+default-members = ["bin/opt8n", "bin/opd8n"]
 resolver = "2"
 
 [workspace.package]

--- a/bin/opd8n/Cargo.toml
+++ b/bin/opd8n/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "opd8n"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish = false
+
+[dependencies]
+# Workspace
+clap.workspace = true
+tokio.workspace = true
+futures.workspace = true
+color-eyre.workspace = true
+op-test-vectors.workspace = true
+
+# External
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
+tracing = { version = "0.1" }

--- a/bin/opd8n/src/cli.rs
+++ b/bin/opd8n/src/cli.rs
@@ -1,0 +1,41 @@
+use clap::Parser;
+use color_eyre::eyre::Result;
+use std::path::PathBuf;
+
+/// Main opd8n CLI
+#[derive(Parser, Clone, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    /// Subcommands for the CLI
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+/// Subcommands for the CLI
+#[derive(Parser, Clone, Debug)]
+pub enum Commands {
+    /// Loads L2 input from a file
+    #[command(visible_alias = "l")]
+    Load {
+        /// Path to the L2 info file
+        #[clap(short, long, help = "Path to the L2 block info file")]
+        input: PathBuf,
+    },
+    // TODO: Add another subcommand that provides an interactive method for generating the
+    // derivation test fixtures
+}
+
+impl Cli {
+    /// Parse the CLI arguments and run the command
+    pub async fn run(self) -> Result<()> {
+        match self.command {
+            Commands::Load { input } => Self::load(input).await,
+        }
+    }
+
+    /// Loads the L2 input file and generates the test fixtures
+    async fn load(input: PathBuf) -> Result<()> {
+        println!("Loading L2 input from file: {:?}", input);
+        Ok(())
+    }
+}

--- a/bin/opd8n/src/main.rs
+++ b/bin/opd8n/src/main.rs
@@ -1,0 +1,10 @@
+use clap::Parser;
+use color_eyre::eyre::Result;
+
+pub mod cli;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    cli::Cli::parse().run().await
+}


### PR DESCRIPTION
**Description**

Stubs out the `opd8n` cli tool for generating derivation test fixtures. Next step is to look into batcher configurability.

**Metadata**

Makes progress on #37