### PR TITLE
chore(deps): bump kona-derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ revm = { version = "12.1", features = ["alloydb", "optimism"] }
 
 # Kona + OP Types
 superchain-registry = "0.2.2"
-kona-derive = { git = "https://github.com/ethereum-optimism/kona", branch = "main", features = ["online"] }
+kona-derive = { git = "https://github.com/ethereum-optimism/kona", rev = "6f7c119d93c854d31de27feadbe11362bafe9cfc", features = ["online"] }
 
 # Internal
 op-test-vectors = { path = "crates/op-test-vectors" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ revm = { version = "12.1", features = ["alloydb", "optimism"] }
 
 # Kona + OP Types
 superchain-registry = "0.2.2"
-kona-derive = { git = "https://github.com/ethereum-optimism/kona", branch = "refcell/bump-alloy-deps", features = ["online"] }
+kona-derive = { git = "https://github.com/ethereum-optimism/kona", branch = "main", features = ["online"] }
 
 # Internal
 op-test-vectors = { path = "crates/op-test-vectors" }


### PR DESCRIPTION
**Description**

Since https://github.com/ethereum-optimism/kona/pull/409 is merged, we can specify a revision for `kona-derive` instead of pointing to this branch.