### PR TITLE
fix(opt8n): Disable `--fork-url` and `--fork-block-number`

### DIFF
--- a/bin/opt8n/src/main.rs
+++ b/bin/opt8n/src/main.rs
@@ -1,7 +1,6 @@
 pub mod opt8n;
 use std::path::PathBuf;
 
-use alloy_rpc_types::anvil::Forking;
 use anvil::cmd::NodeArgs;
 use clap::Parser;
 use color_eyre::eyre;

--- a/bin/opt8n/src/main.rs
+++ b/bin/opt8n/src/main.rs
@@ -59,16 +59,15 @@ async fn main() -> eyre::Result<()> {
     let node_args = args.node_args.clone();
     let opt8n_args = args.command.get_opt8n_args();
 
-    let evm_options = node_args.evm_opts.clone();
-    let forking = evm_options.fork_url.as_ref().map(|fork_url| Forking {
-        json_rpc_url: Some(fork_url.url.clone()),
-        block_number: evm_options.fork_block_number,
-    });
+    if node_args.evm_opts.fork_url.is_some() || node_args.evm_opts.fork_block_number.is_some() {
+        return Err(eyre::eyre!(
+            "Forking is not supported in opt8n, please specify prestate with a genesis file"
+        ));
+    }
 
     let node_config = node_args.clone().into_node_config();
     let mut opt8n = Opt8n::new(
         Some(node_config),
-        forking,
         opt8n_args.output.clone(),
         opt8n_args.genesis.clone(),
     )

--- a/bin/opt8n/src/opt8n.rs
+++ b/bin/opt8n/src/opt8n.rs
@@ -2,10 +2,7 @@
 
 use alloy_eips::eip2718::Encodable2718;
 use alloy_eips::BlockId;
-use alloy_rpc_types::{
-    anvil::Forking,
-    trace::geth::{PreStateConfig, PreStateFrame},
-};
+use alloy_rpc_types::trace::geth::{PreStateConfig, PreStateFrame};
 use anvil::{cmd::NodeArgs, eth::EthApi, NodeConfig, NodeHandle};
 use anvil_core::eth::block::Block;
 use anvil_core::eth::transaction::PendingTransaction;

--- a/bin/opt8n/src/opt8n.rs
+++ b/bin/opt8n/src/opt8n.rs
@@ -33,7 +33,6 @@ pub struct Opt8n {
     pub eth_api: EthApi,
     pub node_handle: NodeHandle,
     pub execution_fixture: ExecutionFixture,
-    pub fork: Option<Forking>,
     pub node_config: NodeConfig,
     pub output_file: PathBuf,
 }
@@ -41,7 +40,6 @@ pub struct Opt8n {
 impl Opt8n {
     pub async fn new(
         node_config: Option<NodeConfig>,
-        fork: Option<Forking>,
         output_file: PathBuf,
         genesis: Option<PathBuf>,
     ) -> Result<Self> {
@@ -64,7 +62,6 @@ impl Opt8n {
             eth_api,
             node_handle,
             execution_fixture: ExecutionFixture::default(),
-            fork,
             node_config,
             output_file,
         })


### PR DESCRIPTION
Addresses #60

This PR removes the `--fork-url` and `--fork-block-number` functionality from opt8n to improve reproducibility and reliability of test fixtures.
