### PR TITLE
chore(opdn): Comment for Exhaustive Match

### DIFF
--- a/bin/opdn/src/cmd/blobs.rs
+++ b/bin/opdn/src/cmd/blobs.rs
@@ -72,6 +72,7 @@ fn extract_blob_data(
                     )
                 }
             },
+            // This is necessary since `TxEnvelope` is marked as non-exhaustive.
             _ => continue,
         };
         let TxKind::Call(to) = tx_kind else { continue };


### PR DESCRIPTION
**Description**

Adds a small comment on why we need an exhaustive match for [`TxEnvelope`](https://docs.rs/alloy-consensus/latest/alloy_consensus/transaction/enum.TxEnvelope.html).