### PR TITLE
feat(op-test-vectors): Re-export Kona Derive

### DIFF
--- a/bin/opdn/src/cmd/from_l2.rs
+++ b/bin/opdn/src/cmd/from_l2.rs
@@ -113,10 +113,7 @@ impl FromL2 {
                 .payload_by_number(i)
                 .await
                 .map_err(|e| eyre!(e))?;
-            ref_payloads.insert(
-                i,
-                crate::cmd::util::to_payload_attributes(l2_payload),
-            );
+            ref_payloads.insert(i, crate::cmd::util::to_payload_attributes(l2_payload));
         }
 
         // Run the pipeline

--- a/crates/op-test-vectors/src/lib.rs
+++ b/crates/op-test-vectors/src/lib.rs
@@ -8,6 +8,10 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+// Re-export `kona-derive` since its types are used in derivation fixtures
+// and the crate is pinned to a specific version.
+pub use kona_derive;
+
 pub mod derivation;
 
 pub mod execution;


### PR DESCRIPTION
**Description**

Re-exports `kona-derive` from `op-test-vectors` so downstream users can import `kona-derive` types used in `op-test-vectors` without needing to manage the `kona-derive` dependency versioning.