### PR TITLE
chore(deps): Bump Superchain Registry Dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6378,9 +6378,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superchain-primitives"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82ed8be21bf40a5103f855c93c7d15091536adfb0aa0a862e6b7c1f93d16c99"
+checksum = "f92c0bb828219b159e625b816e9248adafb028eabb86917b0dfbca9c658c0990"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6394,9 +6394,9 @@ dependencies = [
 
 [[package]]
 name = "superchain-registry"
-version = "0.2.2"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fa9ab00dc58bbd4fb05e46ccafee39eaf777840c156e30c82f629e73d8cbe2"
+checksum = "acc582cdafa06eb8593303a94cc216d6f54ae6c10fabf80f4c13cb7ea6e127ff"
 dependencies = [
  "hashbrown",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ forge-script = { git = "https://github.com/foundry-rs/foundry", rev = "c600237f3
 revm = { version = "12.1", features = ["alloydb", "optimism"] }
 
 # Kona + OP Types
-superchain-registry = "0.2.2"
+superchain-registry = "0.2.6"
 kona-derive = { git = "https://github.com/ethereum-optimism/kona", rev = "4e57dd35ea08b31d0baa293c7a12165f28e6cd92", features = ["online"] }
 
 # Internal


### PR DESCRIPTION
**Description**

Bumps the `superchain-registry` dependency version to [`0.2.6`](https://crates.io/crates/superchain-registry).